### PR TITLE
Add SHA-1 flag for code signing

### DIFF
--- a/Base/Configurations/Debug.xcconfig
+++ b/Base/Configurations/Debug.xcconfig
@@ -47,5 +47,5 @@ STRIP_INSTALLED_PRODUCT = NO
 // The optimization level (-Onone, -O, -Osize) for the produced Swift binary
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 
-// Disable Developer ID timestamping
-OTHER_CODE_SIGN_FLAGS = --timestamp=none
+// Use a faster hashing algorithm for signing and disable Developer ID timestamping
+OTHER_CODE_SIGN_FLAGS = --digest-algorithm=sha1 --timestamp=none


### PR DESCRIPTION
This improves incremental build time by using a faster signing algo (I believe the default is SHA-256). I don't know of any issues with this, and have used it successfully on both real devices and simulators, although feel free to chime in if there are any potential pitfalls.